### PR TITLE
Update IP Versions

### DIFF
--- a/MPFS_DISCOVERY_KIT_REFERENCE_DESIGN.tcl
+++ b/MPFS_DISCOVERY_KIT_REFERENCE_DESIGN.tcl
@@ -150,7 +150,7 @@ if { [file exists $project_dir/$project_name.prjx] } {
 		download_core -vlnv {Actel:SgCore:PF_CCC:*} -location {www.microchip-ip.com/repositories/SgCore}
 		download_core -vlnv {Actel:DirectCore:CORERESET_PF:*} -location {www.microchip-ip.com/repositories/DirectCore}
 		download_core -vlnv {Microsemi:SgCore:PFSOC_INIT_MONITOR:*} -location {www.microchip-ip.com/repositories/SgCore}
-		download_core -vlnv {Actel:DirectCore:COREAXI4INTERCONNECT:2.8.103} -location {www.microchip-ip.com/repositories/DirectCore}
+		download_core -vlnv {Actel:DirectCore:COREAXI4INTERCONNECT:2.9.100} -location {www.microchip-ip.com/repositories/DirectCore}
 		download_core -vlnv {Actel:SgCore:PF_CLK_DIV:*} -location {www.microchip-ip.com/repositories/SgCore}
 		download_core -vlnv {Actel:SgCore:PF_DRI:*} -location {www.microchip-ip.com/repositories/SgCore}
 		download_core -vlnv {Actel:SgCore:PF_NGMUX:*} -location {www.microchip-ip.com/repositories/SgCore}
@@ -521,9 +521,9 @@ configure_tool -name {PLACEROUTE} -params {DELAY_ANALYSIS:MAX} -params {EFFORT_L
 
 if {[info exists SYNTHESIZE]} {
     run_tool -name {SYNTHESIZE}
-} elseif {[info exists PLACEROUTE]} {
+} if {[info exists PLACEROUTE]} {
     run_tool -name {PLACEROUTE}
-} elseif {[info exists VERIFY_TIMING]} {
+} if {[info exists VERIFY_TIMING]} {
     run_tool -name {VERIFYTIMING}
 }
 

--- a/script_support/components/DMA_INITIATOR.tcl
+++ b/script_support/components/DMA_INITIATOR.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFireSoC
 # Part Number: MPFS095T-1FCSG325E
 # Create and Configure the core component DMA_INITIATOR
-create_and_configure_core -core_vlnv {Actel:DirectCore:COREAXI4INTERCONNECT:2.8.103} -component_name {DMA_INITIATOR} -params {\
+create_and_configure_core -core_vlnv {Actel:DirectCore:COREAXI4INTERCONNECT:2.9.100} -component_name {DMA_INITIATOR} -params {\
 "ADDR_WIDTH:32"  \
 "CROSSBAR_MODE:0"  \
 "DATA_WIDTH:64"  \

--- a/script_support/components/FIC0_INITIATOR.tcl
+++ b/script_support/components/FIC0_INITIATOR.tcl
@@ -2,7 +2,7 @@
 # Family: PolarFireSoC
 # Part Number: MPFS095T-1FCSG325E
 # Create and Configure the core component FIC0_INITIATOR
-create_and_configure_core -core_vlnv {Actel:DirectCore:COREAXI4INTERCONNECT:2.8.103} -component_name {FIC0_INITIATOR} -params {\
+create_and_configure_core -core_vlnv {Actel:DirectCore:COREAXI4INTERCONNECT:2.9.100} -component_name {FIC0_INITIATOR} -params {\
 "ADDR_WIDTH:38"  \
 "CROSSBAR_MODE:0"  \
 "DATA_WIDTH:64"  \


### PR DESCRIPTION
Updates the IP versions to be compatible w/ SHLS 2025.1. I only updated the IPs that were updated in the Icicle Kit ref design.